### PR TITLE
Publish package to nuget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**obj
+**bin
+**dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **obj
 **bin
 **dist
+**.env

--- a/Consul.Client/Consul.Client.csproj
+++ b/Consul.Client/Consul.Client.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Consul" Version="1.6.10.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/Consul.Client/Consul.Client.csproj
+++ b/Consul.Client/Consul.Client.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackageId>13angs.Consul.Client</PackageId>
+    <Version>0.0.1</Version>
+    <Authors>13angs</Authors>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Consul.Client/ConsulConfig.cs
+++ b/Consul.Client/ConsulConfig.cs
@@ -1,0 +1,10 @@
+namespace Consul.Client
+{
+    public class ConsulConfig
+    {
+        public Uri? ServiceDiscoveryAddress { get; set; }
+        public Uri? ServiceAddress { get; set; }
+        public string? ServiceName { get; set; }
+        public string? ServiceId { get; set; }
+    }
+}

--- a/Consul.Client/ConsulConfigExtension.cs
+++ b/Consul.Client/ConsulConfigExtension.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Consul.Client
+{
+    public static class ConsulConfigExtensions
+  {
+    public static ConsulConfig GetConsulConfig(this IConfiguration configuration)
+    {
+      if (configuration == null)
+      {
+        throw new ArgumentNullException(nameof(configuration));
+      }
+
+      var consulConfig = new ConsulConfig
+      {
+        ServiceDiscoveryAddress = new System.Uri(configuration["ConsulConfig:serviceDiscoveryAddress"]),
+        ServiceAddress = new System.Uri(configuration["ConsulConfig:serviceAddress"]),
+        ServiceName = configuration["ConsulConfig:serviceName"],
+        ServiceId = configuration["ConsulConfig:serviceId"]
+      };
+
+      return consulConfig;
+    }
+  }
+}

--- a/Consul.Client/ConsulServiceDiscoveryExtension.cs
+++ b/Consul.Client/ConsulServiceDiscoveryExtension.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Consul.Client
+{
+    public static class ServiceDiscoveryExtensions
+    {
+        public static void RegisterConsulServices(this IServiceCollection services, ConsulConfig consulConfig)
+        {
+            if (consulConfig == null)
+            {
+                throw new ArgumentNullException(nameof(ConsulConfig));
+            }
+
+            var consulClient = CreateConsulClient(consulConfig);
+
+            services.AddSingleton(consulConfig);
+            services.AddHostedService<ConsulServiceDiscoveryHostedService>();
+            services.AddSingleton<IConsulClient, ConsulClient>(p => consulClient);
+        }
+
+        private static ConsulClient CreateConsulClient(ConsulConfig ConsulConfig)
+        {
+            return new ConsulClient(config =>
+            {
+                config.Address = ConsulConfig.ServiceDiscoveryAddress;
+            });
+        }
+    }
+}

--- a/Consul.Client/ConsulServiceDiscoveryHostedService.cs
+++ b/Consul.Client/ConsulServiceDiscoveryHostedService.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Consul.Client
+{
+  public class ConsulServiceDiscoveryHostedService : IHostedService
+  {
+    private readonly IConsulClient _client;
+    private readonly ConsulConfig _config;
+    private string? _registrationId;
+    public ConsulServiceDiscoveryHostedService(IConsulClient client, ConsulConfig config)
+    {
+      _client = client;
+      _config = config;
+    }
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+      _registrationId = $"{_config.ServiceName}-{_config.ServiceId}";
+      var registration = new AgentServiceRegistration
+      {
+        ID = _registrationId,
+        Name = _config.ServiceName,
+        Address = _config.ServiceAddress!.Host,
+        Port = _config.ServiceAddress.Port
+      };
+      await _client.Agent.ServiceDeregister(registration.ID, cancellationToken);
+      await _client.Agent.ServiceRegister(registration, cancellationToken);
+    }
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+      await _client.Agent.ServiceDeregister(_registrationId, cancellationToken);
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,34 @@
 # Dotnet consul register
 
+## Usage:
+
+- install the package
+
+```bash
+dotnet add package 13angs.Consul.Client --version 0.0.1
+```
+
+- register the service in DI container
+
+```csharp
+var consulConfig = Configuration.GetConsulConfig();
+builder.Services.RegisterConsulServices(consulConfig);
+```
+
+- update the appsetting.json
+
+```json
+{
+    "ConsulConfig": {
+        "ServiceDiscoveryAddress": "http://dcc-consul-server1:8500",
+        "ServiceAddress": "http://localhost:5117",
+        "ServiceName": "dcc-sample",
+        "ServiceId": "v1"
+    }
+}
+```
+
+- Done!.
+
 # References
 1. https://learn.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # Dotnet consul register
+
+# References
+1. https://learn.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli

--- a/Sample/Program.cs
+++ b/Sample/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/Sample/Program.cs
+++ b/Sample/Program.cs
@@ -1,4 +1,12 @@
+using Consul.Client;
+
 var builder = WebApplication.CreateBuilder(args);
+
+var Configuration = builder.Configuration;
+
+var consulConfig = Configuration.GetConsulConfig();
+builder.Services.RegisterConsulServices(consulConfig);
+
 var app = builder.Build();
 
 app.MapGet("/", () => "Hello World!");

--- a/Sample/Properties/launchSettings.json
+++ b/Sample/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:15536",
+      "sslPort": 44358
+    }
+  },
+  "profiles": {
+    "Sample": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5117",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
+  <ItemGroup>
+    <ProjectReference Include="..\Consul.Client\Consul.Client.csproj" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <ItemGroup>
-    <ProjectReference Include="..\Consul.Client\Consul.Client.csproj" />
+    <!-- <ProjectReference Include="..\Consul.Client\Consul.Client.csproj" /> -->
+    <PackageReference Include="13angs.Consul.Client" Version="0.0.1" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Sample/appsettings.Development.json
+++ b/Sample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/Sample/appsettings.Development.json
+++ b/Sample/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConsulConfig": {
+    "ServiceDiscoveryAddress": "http://dcc-consul-server1:8500",
+    "ServiceAddress": "http://localhost:5117",
+    "ServiceName": "dcc-sample",
+    "ServiceId": "v1"
   }
 }

--- a/Sample/appsettings.json
+++ b/Sample/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/Sample/appsettings.json
+++ b/Sample/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConsulConfig": {
+    "ServiceDiscoveryAddress": "http://dcc-consul-server1:8500",
+    "ServiceAddress": "http://localhost:5117",
+    "ServiceName": "dcc-sample",
+    "ServiceId": "v1"
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  dcc-consul-server1:
+    image: consul:latest
+    container_name: dcc-consul-server1
+    restart: always
+
+    ports:
+      - "8500:8500"
+    
+    command: "agent -bootstrap-expect=2"
+
+    networks:
+      - dcc-network
+    
+    volumes:
+      - ./server1.json:/consul/config/server1.json:ro
+
+  dcc-consul-server2:
+    image: consul:latest
+    container_name: dcc-consul-server2
+    restart: always
+    
+    command: "agent -bootstrap-expect=2"
+
+    networks:
+      - dcc-network
+    
+    volumes:
+      - ./server2.json:/consul/config/server2.json:ro
+
+networks:
+  dcc-network:
+    external: true
+    name: dcc-network

--- a/server1.json
+++ b/server1.json
@@ -1,0 +1,16 @@
+{
+    "node_name": "dcc-consul-server1",
+    "server": true,
+    "ui_config": {
+      "enabled": true
+    },
+    "data_dir": "/consul/data",
+    "addresses": {
+      "http": "0.0.0.0"
+    },
+    "retry_join": ["dcc-consul-server2"],
+    "connect": {
+      "enabled": true
+    }
+  }
+  

--- a/server2.json
+++ b/server2.json
@@ -1,0 +1,16 @@
+{
+    "node_name": "dcc-consul-server2",
+    "server": true,
+    "ui_config": {
+      "enabled": true
+    },
+    "data_dir": "/consul/data",
+    "addresses": {
+      "http": "0.0.0.0"
+    },
+    "retry_join": ["dcc-consul-server2"],
+    "connect": {
+      "enabled": true
+    }
+  }
+  


### PR DESCRIPTION
## Todos
- setup service discovery server using consul
- add sample project
- add the library
- install the package

```bash
dotnet add package Microsoft.Extensions.Configuration --version 6.0.1 && \
dotnet add package Consul --version 1.6.10.7 && \
dotnet add package Microsoft.Extensions.Hosting --version 6.0.1
```

- Create ConsulConfig Model
- Create ConsulConfigExtension
- Register the ConsulConfig in Program.cs
- Create ConsulServiceDiscoveryHostedService
- Register it in Program.cs
- create ConsulServiceDiscoveryExtension
- Register using ConsulServiceDiscoveryExtension instead

## References
1. https://github.com/13angs/simple-ecom
2. https://github.com/13angs/simple-ecom/issues/1
3. https://learn.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package-using-the-dotnet-cli